### PR TITLE
add check.names=FALSE to data.frame command

### DIFF
--- a/R/nonmissing_per_group.R
+++ b/R/nonmissing_per_group.R
@@ -96,11 +96,11 @@ nonmissing_per_group <- function(omicsData = NULL, e_data = NULL, groupDF=NULL, 
   
   nonmissing<- nonmissing_per_grp(as.matrix(temp_data3),group_dat)
   
-  nonmissing<- data.frame(nonmissing)
+  nonmissing<- data.frame(nonmissing, check.names = FALSE)
   
   colnames(nonmissing)<- unique(group_dat)
   
-  nonmiss_totals<- data.frame(Mass_Tag_ID,nonmissing,stringsAsFactors = FALSE)
+  nonmiss_totals<- data.frame(Mass_Tag_ID,nonmissing,stringsAsFactors = FALSE, check.names = FALSE)
   
   names(nonmiss_totals)[1] <- cname_id
   


### PR DESCRIPTION
If there is a numerical value starting the column names, then an X is placed in front of it, so it will not match the other names