### PR TITLE
fix 0->NA replacement not working for abundance data with mixed NA an…

### DIFF
--- a/R/as.omicsData.R
+++ b/R/as.omicsData.R
@@ -1638,7 +1638,7 @@ pre_flight <- function (e_data,
   # Depending on scale, check if there are zeros in edata and auto-remove all 0/na rows
   if (data_scale == 'abundance') {
 
-    if(any(na.omit(e_data == 0))){
+    if(any(e_data == 0, na.rm = TRUE)){
       # Exchange 0 for NA in edata.
       e_data <- replace_zeros(edata = e_data,
                               edata_cname = edata_cname)


### PR DESCRIPTION
https://github.com/pmartR/pmartR/blob/74730d9f10c2747b7d03719520248204193080f7/R/as.omicsData.R#L1641

Case:  
- There are zeros and NA's in the data and all the zeros share a row with an NA
- `na.omit(edata == 0)` returns only rows _without_ zeros since the ones that do have an NA in the row too
- any() evaluates to FALSE

Changing to just have any() handle NA ignoring