### PR TITLE
Release 2.5.1 for CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: pmartR
 Type: Package
 Title: Panomics Marketplace - Quality Control and Statistical Analysis for Panomics Data
-Version: 2.5.0
-Date: 2025-04-21
+Version: 2.5.1
+Date: 2025-10-21
 Authors@R: c(
     person("Lisa", "Bramer", email = "lisa.bramer@pnnl.gov", role = c("aut", "cre")), 
     person("Kelly", "Stratton", email = "kelly.stratton@pnnl.gov", role = c("aut")), 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,3 +2,7 @@
 
 Fixed NOTE's about updating R-version to > 4.1.0 to accommodate base pipe operator and new lambda function syntax.
 
+# Version 2.5.1 October, 2025
+
+Fixed package deprecations that arose from an update to RcppArmadillo. Includes a new package flag during installation (-DARMA_USE_CURRENT) in addition to replacing functions arma::conv_to::from and arma::is_finite to arma::as_scalar and std::isfinite respectively.
+


### PR DESCRIPTION
Refer to https://github.com/pmartR/pmartR/pull/363 for compliance with CRAN requirements.